### PR TITLE
Add support for laravel:9.0 framework

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": "^7.3|^8.0",
         "cebe/php-openapi": "^1.5",
-        "laravel/framework": "^6.0|^7.0|^8.0",
+        "laravel/framework": "^6.0|^7.0|^8.0|^9.0",
         "ext-json": "*"
     },
     "require-dev": {


### PR DESCRIPTION
Add support for laravel 9 framework

![brocc-open-api-laravel-9](https://github.com/brocc-ab/laravel-openapi/assets/8319659/232eed08-302a-4016-90b6-a03fec916b70)
